### PR TITLE
import _get_height_ratios from modelplots instead of plots

### DIFF
--- a/metran/plots.py
+++ b/metran/plots.py
@@ -2,7 +2,11 @@
 import matplotlib.pyplot as plt
 import numpy as np
 from pandas import Timestamp
-from pastas.modelplots import _get_height_ratios
+import pastas
+if pastas.__version__ < '0.19.0':
+    from pastas.plots import _get_height_ratios
+else:
+    from pastas.modelplots import _get_height_ratios
 
 
 class MetranPlot:

--- a/metran/plots.py
+++ b/metran/plots.py
@@ -2,7 +2,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 from pandas import Timestamp
-from pastas.plots import _get_height_ratios
+from pastas.modelplots import _get_height_ratios
 
 
 class MetranPlot:


### PR DESCRIPTION
_get_height_ratios was moved to modelplots for Pastas version 0.19.0.
https://github.com/pastas/pastas/commit/6273618bdce0011c4338c750eade551922e12b00

Metran currently does not work with Paster version 0.19.0 or newer because there were some adjustments to Pastas.